### PR TITLE
Adding com.sun.xml.security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     compile "ch.qos.logback:logback-classic:1.2.1"
     compile "io.arrow-kt:arrow-effects-instances:$arrow_version"
     compile "io.arrow-kt:arrow-instances-data:$arrow_version"
-    //compile "com.sun.org.apache.xml.internal.security.utils"
     compile "com.sun.xml.security:xml-security-impl:1.0"
     
     // Test

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,9 @@ dependencies {
     compile "ch.qos.logback:logback-classic:1.2.1"
     compile "io.arrow-kt:arrow-effects-instances:$arrow_version"
     compile "io.arrow-kt:arrow-instances-data:$arrow_version"
-
+    //compile "com.sun.org.apache.xml.internal.security.utils"
+    compile "com.sun.xml.security:xml-security-impl:1.0"
+    
     // Test
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile "io.ktor:ktor-server-test-host:$ktor_version"


### PR DESCRIPTION
This allows the project to compile the tests with OpenJDK 9.

Before, I was getting:
```
./gradlew clean build

...
Download https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar
w: -Xcoroutines has no effect: coroutines are enabled anyway in 1.3 and beyond
e: /home/mendezr/development/misc/ArrowInPractice/src/test/kotlin/com/fortysevendeg/arrowinpractice/AuthExtensions.kt: (3, 55): Symbol is declared in module 'java.xml.crypto' which does not export package 'com.sun.org.apache.xml.internal.security.utils'
e: /home/mendezr/development/misc/ArrowInPractice/src/test/kotlin/com/fortysevendeg/arrowinpractice/AuthExtensions.kt: (20, 14): Symbol is declared in module 'java.xml.crypto' which does not export package 'com.sun.org.apache.xml.internal.security.utils'
e: /home/mendezr/development/misc/ArrowInPractice/src/test/kotlin/com/fortysevendeg/arrowinpractice/AuthExtensions.kt: (20, 21): Symbol is declared in module 'java.xml.crypto' which does not export package 'com.sun.org.apache.xml.internal.security.utils'
> Task :compileTestKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestKotlin'.
> Compilation error. See log for more details

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 2m 28s
7 actionable tasks: 6 executed, 1 up-to-date
```

```
~/development/misc/ArrowInPractice❱✔≻ java -version
openjdk version "9-Debian"
OpenJDK Runtime Environment (build 9-Debian+0-9b181-4bpo91)
OpenJDK 64-Bit Server VM (build 9-Debian+0-9b181-4bpo91, mixed mode)
```

